### PR TITLE
 Fix for WSL path folders appearing in project dir

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -69,7 +69,7 @@ config.set = function(options) {
   if (!path.isAbsolute(config.serve))
     config.serve = path.normalize(path.join(process.cwd(), config.serve))
 
-  config.appData = utils.getAppDataDirectory(config.id)
+  config.appData = utils.getAppDataDirectory(process, config.id)
 
   config.execute = Array.isArray(config.execute) ? config.execute : config.execute ? [config.execute] : []
   config.execute = config.execute.map(s => typeof s === 'string' ? { command: s } : s)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,25 +132,31 @@ utils.promisify = function(fn) {
 }
 
 utils.wrightDataDirectory = function(process) {
-  const HOME = x.env.HOMEPATH || x.env.HOME || ''
-  
-  const ubuntuOnWindowsPath = 
+  const home = process.env.HOMEPATH || process.env.HOME || ''
+
+  const wslPath =
     [process.env]
     .filter( x => x.WSL_DISTRO_NAME )
     .flatMap( x => x.PATH ? [x.PATH] : [] )
+
+  const wslUsername =
+    wslPath
     .flatMap(  x => x.split(':') )
     .flatMap( x => x.split('/mnt/c/Users').slice(1) )
     .flatMap( x => x.split('/').slice(1,2) )
+
+  const ubuntuOnWindowsPath = 
+    wslUsername
     .map(
-      username => ({ 
+      username => ({
         node: '/mnt/c/Users/'+username+'/.wright', 
         chrome: 'C:\\Users\\'+username+'\\.wright' 
       })
     )
 
   const otherwise = 
-    [process]
-    .map( x => path.join(HOME, '.wright') )
+    [home]
+    .map( x => path.join(x, '.wright') )
     .map( x => ({ node:x, chrome: x }) )
 
   return [].concat(ubuntuOnWindowsPath, otherwise)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,6 +132,8 @@ utils.promisify = function(fn) {
 }
 
 utils.wrightDataDirectory = function(process) {
+  const HOME = x.env.HOMEPATH || x.env.HOME || ''
+  
   const ubuntuOnWindowsPath = 
     [process.env]
     .filter( x => x.WSL_DISTRO_NAME )
@@ -146,19 +148,12 @@ utils.wrightDataDirectory = function(process) {
       })
     )
 
-  const windows = 
+  const otherwise = 
     [process]
-    .filter( x => x.platform === 'win32' )
-    .map( x => path.join(x.env.HOMEPATH, 'wright') )
+    .map( x => path.join(HOME, '.wright') )
     .map( x => ({ node:x, chrome: x }) )
 
-  const linux = 
-    [process]
-    .filter( x => x.platform !== 'win32' )
-    .map( x => path.join(x.env.HOME || '', '.wright') )
-    .map( x => ({ node:x, chrome: x }) )
-
-  return [].concat(ubuntuOnWindowsPath, windows, linux)
+  return [].concat(ubuntuOnWindowsPath, otherwise)
     .slice(0,1)
     .concat({ node: '.wright', chrome: '.wright' })
     .shift()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,21 +131,45 @@ utils.promisify = function(fn) {
   })
 }
 
-utils.wrightDataDirectory = (function() {
-  const ubuntuOnWindows = (process.env.PATH || '').match(/:\/mnt\/c\/users\/([a-z0-9-_]+)/i) // eslint-disable-line
-  return process.platform === 'win32'
-    ? path.join(process.env.HOMEPATH || '', 'wright') // eslint-disable-line
-    : ubuntuOnWindows
-      ? ('C:\\Users\\' + ubuntuOnWindows[1] + '\\.wright')
-      : path.join(process.env.HOME || '', '.wright') // eslint-disable-line
-}())
+utils.wrightDataDirectory = function(process) {
+  const ubuntuOnWindowsPath = 
+    [process.env]
+    .filter( x => x.WSL_DISTRO_NAME )
+    .flatMap( x => x.PATH ? [x.PATH] : [] )
+    .flatMap(  x => x.split(':') )
+    .flatMap( x => x.split('/mnt/c/Users').slice(1) )
+    .flatMap( x => x.split('/').slice(1,2) )
+    .map(
+      username => ({ 
+        node: '/mnt/c/Users/'+username+'/.wright', 
+        chrome: 'C:\\Users\\'+username+'\\.wright' 
+      })
+    )
 
-utils.getAppDataDirectory = function(name) {
-  const wrightPath = utils.wrightDataDirectory
-      , projectPath = path.join(wrightPath, name)
+  const windows = 
+    [process]
+    .filter( x => x.platform === 'win32' )
+    .map( x => path.join(x.env.HOMEPATH, 'wright') )
+    .map( x => ({ node:x, chrome: x }) )
+
+  const linux = 
+    [process]
+    .filter( x => x.platform !== 'win32' )
+    .map( x => path.join(x.env.HOME || '', '.wright') )
+    .map( x => ({ node:x, chrome: x }) )
+
+  return [].concat(ubuntuOnWindowsPath, windows, linux)
+    .slice(0,1)
+    .concat({ node: '.wright', chrome: '.wright' })
+    .shift()
+}
+
+utils.getAppDataDirectory = function(process, name) {
+  const wrightPath = utils.wrightDataDirectory(process)
+      , projectPath = path.join(wrightPath.chrome, name)
 
   try {
-    fs.mkdirSync(wrightPath)
+    fs.mkdirSync(wrightPath.node)
   } catch (_) {
     // don't care for errors (they exist)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wright",
-  "version": "2.0.0-beta35",
+  "version": "2.0.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -75,10 +75,26 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "bss": {
       "version": "1.6.3",
@@ -196,6 +212,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -203,6 +225,27 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -228,6 +271,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -310,16 +378,51 @@
         }
       }
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
       "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "glob-parent": {
       "version": "5.0.0",
@@ -329,10 +432,25 @@
         "is-glob": "^4.0.1"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "http-errors": {
       "version": "1.7.3",
@@ -362,6 +480,16 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -409,6 +537,18 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -447,6 +587,24 @@
         "@types/estree": "0.0.39"
       }
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
@@ -477,6 +635,15 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
     "minimist": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -503,12 +670,33 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -534,6 +722,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -629,6 +823,15 @@
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
       }
     },
     "rollup": {
@@ -791,6 +994,17 @@
         }
       }
     },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -814,9 +1028,30 @@
         "has-flag": "^3.0.0"
       }
     },
+    "tape": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
+      "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.4",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.11.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
+      }
+    },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
@@ -882,6 +1117,12 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prepublishOnly": "npm run build",
     "try:rollup": "npm install && cd examples/rollup && npm install && node wright",
     "try:mithril": "npm install && cd examples/mithril && npm install && node rollup",
-    "try:simple": "npm install && cd examples/simple && node ../../bin/wright -r \"window.reload()\" index.html"
+    "try:simple": "npm install && cd examples/simple && node ../../bin/wright -r \"window.reload()\" index.html",
+    "test": "tape test/**"
   },
   "repository": "porsager/wright",
   "dependencies": {
@@ -34,9 +35,13 @@
   "devDependencies": {
     "bss": "1.6.3",
     "mithril": "1.1.6",
+    "pws": "1.0.2",
     "rollup": "1.16.7",
     "rollup-plugin-buble": "0.19.8",
     "rollup-plugin-commonjs": "10.0.1",
-    "rollup-plugin-node-resolve": "5.2.0"
+    "rollup-plugin-node-resolve": "5.2.0",
+    "serve-static": "1.13.2",
+    "tape": "^4.11.0",
+    "ws": "6.0.0"
   }
 }

--- a/test/data-dir.js
+++ b/test/data-dir.js
@@ -1,0 +1,83 @@
+const test = require('tape')
+const { wrightDataDirectory, getAppDataDirectory } = require('../lib/utils')
+
+const fakeProcess = {
+    linux(){
+        return {
+            platform: 'linux',
+            env: {
+                HOME: '/home/porsager',
+                PATH: [
+                    '/home/porsager/something/something',
+                    '/usr/bin/something'
+                ]
+                .join(':')
+            }
+        }
+    },
+    windows(){
+        return {
+            platform: 'win32',
+            env: {
+                HOMEPATH: 'C:\\Users\\porsager',
+                PATH: [
+                    'C:\\Users\\porsager\\something\\something',
+                    'C:\\Program Files (x86)\\something',
+                    'C:\\Program Files\\something',
+                ]
+                .join(';')
+            }
+        }
+    },
+    wsl(){
+        return {
+            platform: 'linux',
+            env: {
+                HOME: '/home/porsager',
+                WSL_DISTRO_NAME: 'Ubuntu-18.04',
+                PATH: [
+                    '/home/porsager/something/something',
+                    '/usr/bin/something',
+                    '/mnt/c/Users/porsager/example'
+                ]
+                .join(':')
+            }
+        }
+    },
+}
+
+// So the test's pass on all platforms (path.join, path.resolve etc)
+const normalize = s => s.replace(/\\/g, '/')
+
+test('linux', (t) => {
+    const process = fakeProcess.linux()
+    const wrightData = wrightDataDirectory(process)
+    const appData = normalize(getAppDataDirectory(process, 'example'))
+    
+    t.equals(normalize(wrightData.chrome), '/home/porsager/.wright', 'Chrome')
+    t.equals(appData, '/home/porsager/.wright/example', 'AppData')
+    t.equals(normalize(wrightData.node), '/home/porsager/.wright', 'Node')
+    t.end()
+})
+
+test('windows', (t) => {
+    const process = fakeProcess.windows()
+    const wrightData = wrightDataDirectory(process)
+    const appData = normalize(getAppDataDirectory(process, 'example'))
+    
+    t.equals(normalize(wrightData.chrome), 'C:/Users/porsager/wright', 'Chrome')
+    t.equals(appData, 'C:/Users/porsager/wright/example', 'AppData')
+    t.equals(normalize(wrightData.node), 'C:/Users/porsager/wright', 'Node')
+    t.end()
+})
+
+test('wsl', (t) => {
+    const process = fakeProcess.wsl()
+    const wrightData = wrightDataDirectory(process)
+    const appData = normalize(getAppDataDirectory(process, 'example'))
+    
+    t.equals(normalize(wrightData.chrome), 'C:/Users/porsager/.wright', 'Chrome')
+    t.equals(appData, 'C:/Users/porsager/.wright/example', 'AppData')
+    t.equals(normalize(wrightData.node), '/mnt/c/Users/porsager/.wright', 'Node')
+    t.end()
+})

--- a/test/data-dir.js
+++ b/test/data-dir.js
@@ -65,9 +65,9 @@ test('windows', (t) => {
     const wrightData = wrightDataDirectory(process)
     const appData = normalize(getAppDataDirectory(process, 'example'))
     
-    t.equals(normalize(wrightData.chrome), 'C:/Users/porsager/wright', 'Chrome')
-    t.equals(appData, 'C:/Users/porsager/wright/example', 'AppData')
-    t.equals(normalize(wrightData.node), 'C:/Users/porsager/wright', 'Node')
+    t.equals(normalize(wrightData.chrome), 'C:/Users/porsager/.wright', 'Chrome')
+    t.equals(appData, 'C:/Users/porsager/.wright/example', 'AppData')
+    t.equals(normalize(wrightData.node), 'C:/Users/porsager/.wright', 'Node')
     t.end()
 })
 


### PR DESCRIPTION
### What / Why

There was an issue where on WSL there would be folders in the project directory named as `C:\Users\:username\.wright`.  

The problem arose because node running in WSL doesn't understand windows paths and treats them as filenames.  Chrome however is not running in the WSL context.  The solution in this branch is to generate distinct paths for usage by Node and by Chrome.

### How to test

I definitely recommend manually testing this on each platform.  But I've added a set of tests that at least document my assumptions about each environment.

I've also modified the utils a bit to make them easier to test.  Hopefully that's ok.  Static properties are now functions.  `process` is passed in as an argument too.

To run the tests:

- npm install
- npm test

### Questions

I use Maybe's to model the uncertain aspects of interacting with `process`.  I also changed how the username is extracted from the path to handle non ASCII usernames.  Basically replace a regex for a string split.  It might be worthwhile to do that in a separate PR or not at all.